### PR TITLE
Added a method to write series with a specific time_precision

### DIFF
--- a/influxdb.go
+++ b/influxdb.go
@@ -217,6 +217,25 @@ func (self *Client) WriteSeries(series []*Series) error {
 	return responseToError(resp, err, true)
 }
 
+type TimePrecision string
+
+const (
+	Second      TimePrecision = "s"
+	Millisecond TimePrecision = "m"
+	Microsecond TimePrecision = "u"
+)
+
+func (self *Client) WriteSeriesWithTimePrecision(series []*Series, timePrecision TimePrecision) error {
+	data, err := json.Marshal(series)
+	if err != nil {
+		return err
+	}
+	url := self.getUrl("/db/" + self.database + "/series")
+	url += fmt.Sprintf("&time_precision=%s", timePrecision)
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(data))
+	return responseToError(resp, err, true)
+}
+
 func (self *Client) Query(query string) ([]*Series, error) {
 	escapedQuery := url.QueryEscape(query)
 	url := self.getUrl("/db/" + self.database + "/series")


### PR DESCRIPTION
I did think about changing the existing WriteSeries method to something with a signature like this:

`func (self *Client) WriteSeries(series []*Series, timePrecision ...TimePrecision) error`

But it didn't feel like a clean solution as you would then need to add multiple checks inside the method to make sure all corner cases are treaded correctly. So I opted for a separate function instead, which also feels a little like doing the same stuff twice but then at least is all clean and tidy :)

This PR is also a fix for issue #3 which described exactly the issue I'm trying to solve.
