### PR TITLE
handle http get error in GetShards

### DIFF
--- a/influxdb.go
+++ b/influxdb.go
@@ -447,6 +447,9 @@ type Shard struct {
 func (self *Client) GetShards() (*LongTermShortTermShards, error) {
 	url := self.getUrlWithUserAndPass("/cluster/shards", self.username, self.password)
 	body, err := self.get(url)
+	if err != nil {
+		return nil, err
+	}
 	shards := &LongTermShortTermShards{}
 	err = json.Unmarshal(body, shards)
 	if err != nil {


### PR DESCRIPTION
Otherwise, the error that's returned is from json.Unmarshal and doesn't
indicate the root cause
