### PR TITLE
Compare to the reference version, not the equivalent version.

### DIFF
--- a/influxdb.go
+++ b/influxdb.go
@@ -543,7 +543,7 @@ func isOrNewerThan(version, reference string) bool {
 		return true
 	}
 	majorMinor := strings.Split(version[1:], ".")[:2]
-	refMajorMinor := strings.Split(version[1:], ".")[:2]
+	refMajorMinor := strings.Split(reference[1:], ".")[:2]
 	if majorMinor[0] > refMajorMinor[0] {
 		return true
 	}


### PR DESCRIPTION
There's a bug in the isOrNewerThan, which compares the source version to the source version, instead of the reference version. This was causing GetShards to fail for influxdb's older than 0.8 (though, perhaps it still fails for 0.8 -- we don't have any of those running yet).
